### PR TITLE
Update start.py

### DIFF
--- a/start.py
+++ b/start.py
@@ -165,8 +165,8 @@ BYTES_SEND = Counter()
 
 
 class Tools:
-    IP = compile("(?:\d{1,3}\.){3}\d{1,3}")
-    protocolRex = compile('"protocol":(\d+)')
+    IP = compile(r"(?:\d{1,3}\.){3}\d{1,3}")
+    protocolRex = compile(r'"protocol":(\d+)')
 
     @staticmethod
     def humanbytes(i: int, binary: bool = False, precision: int = 2):


### PR DESCRIPTION
Fix for:
start.py:169: SyntaxWarning: invalid escape sequence '\d'
  protocolRex = compile('"protocol":(\d+)')
start.py:168: SyntaxWarning: invalid escape sequence '\d'
  IP = compile("(?:\d{1,3}\.){3}\d{1,3}")